### PR TITLE
fix: more-link -> more-info

### DIFF
--- a/Week09/CrustaceansIndividual.md
+++ b/Week09/CrustaceansIndividual.md
@@ -7,7 +7,7 @@ Create a hyperlink button that will send the user to more crustacean information
 ### HTML Updates
 1. In the HTML file, underneath the "Subscribe" `<div></div>`, add a new `a` element
 1. Set the `class` attribute of the `a` to "btn" so it appears as a button
-1. Set the `id` attribute of the `a` to "more-link" so it is accessible in the CSS
+1. Set the `id` attribute of the `a` to "more-info" so it is accessible in the CSS
 1. Set the `href` attribute of the `a` to "https://en.wikipedia.org/wiki/Crustacean" so it goes there when clicked
 
 ### CSS Updates


### PR DESCRIPTION
Step 3 of the HTML Update section previously specified `more-link` as the id of the anchor element. The CSS Updates section refers to the anchor element as `more-info`.
![image](https://github.com/hytechclub/web-101/assets/27352901/134cfb22-43a0-4924-a5fc-64fa108ec2af)
