### PR TITLE
feat: week 1 updated Google Images url

### DIFF
--- a/Week01/CodeAlong.md
+++ b/Week01/CodeAlong.md
@@ -66,7 +66,7 @@ This is looking rad, but what's missing? Almost every website has at least one i
 ### Finding an Image
 The first thing to do is find an image. Images on websites have URLs which tell the browser where to look for them. Follow the instructions below to find the URL (or _address_) of an image, and copy it.
 
-1. Open a new browser tab and go to [Google Images](https://google.com/images/)
+1. Open a new browser tab and go to [Google Images](https://www.google.com/imghp?hl=en&tab=ri&ogbl)
 1. Search for something appropriate (such as "cats")
 1. Click on the image you would like to use
 1. When it appears, right click and select "Copy image address"


### PR DESCRIPTION
The trailing slash in `https://google.com/images/` causes a 404 when performing a top level navigation or following a link, such as in the code along instructions:
<img width="1269" height="456" alt="image" src="https://github.com/user-attachments/assets/2b7fc732-dee7-4063-8900-664a272d41f6" />

Surprisingly, omitting the trailing slash results in successful redirect to google.com/imghp. I don't understand why Google would configure this way, but the change in this PR circumvents the issue.

I also received conflicting explanations from copilot:
<img width="605" height="237" alt="image" src="https://github.com/user-attachments/assets/651a3882-29ae-45e4-ba93-82e9b68d3566" />
<img width="594" height="334" alt="image" src="https://github.com/user-attachments/assets/6a0f5d2f-0809-4b37-98b5-c7e8eea52d63" />
